### PR TITLE
feat(#11): add custom textarea

### DIFF
--- a/src/components/Textarea.jsx
+++ b/src/components/Textarea.jsx
@@ -1,0 +1,37 @@
+import { useId, useState } from 'react';
+
+export default function Textarea({ limit, label }) {
+  const [textareaValue, setTextareaValue] = useState('');
+
+  const textareaId = useId();
+
+  return (
+    <label
+      className="w-full font-robotoFlex text-base font-medium leading-5 text-on-background-2"
+      htmlFor={textareaId}
+    >
+      {label}
+      <div className="mt-2 flex h-56 w-full flex-col gap-6 rounded-lg border border-surface-1 bg-surface-2 p-4 text-on-surface-1">
+        <textarea
+          name=""
+          id={textareaId}
+          className="h-full resize-none bg-surface-2 font-normal outline-none"
+          onChange={(e) => setTextareaValue(e.target.value)}
+          value={textareaValue}
+          maxLength={limit}
+        />
+        <div className="flex justify-end place-self-end text-sm font-normal leading-4 text-on-background-2">
+          {textareaValue.length} / {limit}
+        </div>
+      </div>
+    </label>
+  );
+}
+
+{
+  /*
+    An example of using the textarea
+
+    <TextArea limit="400" label="Опис:" />
+  */
+}


### PR DESCRIPTION
closes #13 #11 

Textarea with the ability to set the number of characters in `limit` prop.

Some screens:
![image](https://github.com/gvary-ua/web-editor/assets/130480023/61c34500-5f13-4f5a-993e-3996f5a86e60)

![image](https://github.com/gvary-ua/web-editor/assets/130480023/8820cf19-c32c-4bc4-ae1b-fd285ee1f8cc)
